### PR TITLE
split long string template into multiple lines for better readability

### DIFF
--- a/src/zipline/finance/transaction.py
+++ b/src/zipline/finance/transaction.py
@@ -44,7 +44,7 @@ class Transaction:
             dt=self.dt,
             amount=self.amount,
             price=self.price,
-            commission=self.commission
+            commission=self.commission,
         )
 
     def to_dict(self):

--- a/src/zipline/finance/transaction.py
+++ b/src/zipline/finance/transaction.py
@@ -34,8 +34,10 @@ class Transaction:
         return self.__dict__[name]
 
     def __repr__(self):
-        template = "{cls}(asset={asset}, dt={dt}," " amount={amount}, price={price}, commission={commission})"
-
+        template = (
+            "{cls}(asset={asset}, dt={dt},"
+            " amount={amount}, price={price}, commission={commission})"
+        )
         return template.format(
             cls=type(self).__name__,
             asset=self.asset,


### PR DESCRIPTION
to pass formatting check